### PR TITLE
feat: JWTOAuthClient supports specifying the account ID when obtaining the access token.

### DIFF
--- a/auth_token.go
+++ b/auth_token.go
@@ -42,6 +42,7 @@ func NewJWTAuth(client *JWTOAuthClient, opt *GetJWTAccessTokenReq) Auth {
 		Scope:       opt.Scope,
 		SessionName: opt.SessionName,
 		client:      client,
+		accountID:   opt.AccountID,
 	}
 }
 
@@ -57,6 +58,7 @@ type jwtOAuthImpl struct {
 	client      *JWTOAuthClient
 	accessToken *string
 	expireIn    int64
+	accountID   *int64
 }
 
 func (r *jwtOAuthImpl) needRefresh() bool {
@@ -71,6 +73,7 @@ func (r *jwtOAuthImpl) Token(ctx context.Context) (string, error) {
 		TTL:         r.TTL,
 		SessionName: r.SessionName,
 		Scope:       r.Scope,
+		AccountID:   r.accountID,
 	})
 	if err != nil {
 		return "", err


### PR DESCRIPTION
https://www.coze.cn/open/docs/developer_guides/oauth_jwt_collaborate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the authentication process to support account-specific access tokens, enabling more granular token requests while preserving existing behaviors.
- **Tests**
	- Added a dedicated test case to validate token retrieval when an account identifier is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->