### PR TITLE
feat: Support section_id for clear conversation

### DIFF
--- a/conversations.go
+++ b/conversations.go
@@ -178,5 +178,6 @@ type clearConversationsResp struct {
 
 type ClearConversationsResp struct {
 	baseModel
+	ID             string `json:"id"`
 	ConversationID string `json:"conversation_id"`
 }

--- a/conversations_test.go
+++ b/conversations_test.go
@@ -179,6 +179,7 @@ func TestConversations(t *testing.T) {
 				return mockResponse(http.StatusOK, &clearConversationsResp{
 					Data: &ClearConversationsResp{
 						ConversationID: "conv1",
+						ID:             "new_section",
 					},
 				})
 			},
@@ -194,6 +195,7 @@ func TestConversations(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "test_log_id", resp.LogID())
 		assert.Equal(t, "conv1", resp.ConversationID)
+		assert.Equal(t, "new_section", resp.ID)
 	})
 
 	// Test List method with default pagination


### PR DESCRIPTION
Fix issue where section Id was not correctly parsed during conversation context clear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new ID field to the response when clearing conversations, providing additional information to end-users.

- **Tests**
  - Updated tests to verify the presence and correctness of the new ID field in conversation clearing responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->