### PR TITLE
feat: Support prologue_delay_duration_ms for audio.rooms.create api

### DIFF
--- a/audio_rooms.go
+++ b/audio_rooms.go
@@ -49,6 +49,8 @@ type RoomConfig struct {
 	AudioConfig     *RoomAudioConfig `json:"audio_config,omitempty"`
 	VideoConfig     *RoomVideoConfig `json:"video_config,omitempty"`
 	PrologueContent string           `json:"prologue_content,omitempty"`
+	// 在进房后等待多长时间播放开场白，默认是500ms，[0, 5000]
+	PrologueDelayDurationMs *int `json:"prologue_delay_duration_ms,omitempty"`
 }
 
 // VideoCodec represents the video codec

--- a/audio_rooms_test.go
+++ b/audio_rooms_test.go
@@ -39,7 +39,8 @@ func TestAudioRooms(t *testing.T) {
 						Codec:           VideoCodecH264,
 						StreamVideoType: StreamVideoTypeMain,
 					},
-					PrologueContent: randomString(10),
+					PrologueContent:         randomString(10),
+					PrologueDelayDurationMs: ptr(100),
 				},
 			})
 			as.Nil(err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a delay (in milliseconds) before prologue content plays when entering an audio room.

* **Tests**
  * Updated test cases to cover the new prologue delay field in audio room creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->