### PR TITLE
fix(example/chat, workflow): align custom HTTP client timeout with st…

### DIFF
--- a/examples/chats/chat_with_image/main.go
+++ b/examples/chats/chat_with_image/main.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/coze-dev/coze-go"
 )
@@ -20,8 +22,15 @@ func main() {
 
 	authCli := coze.NewTokenAuth(token)
 
+	customClient := &http.Client{
+		Timeout: time.Minute * 20,
+	}
+
 	// Init the Coze client through the access_token.
-	cozeCli := coze.NewCozeAPI(authCli, coze.WithBaseURL(os.Getenv("COZE_API_BASE")))
+	cozeCli := coze.NewCozeAPI(authCli,
+		coze.WithBaseURL(os.Getenv("COZE_API_BASE")),
+		coze.WithHttpClient(customClient),
+	)
 
 	ctx := context.Background()
 

--- a/examples/chats/stream/main.go
+++ b/examples/chats/stream/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"time"
 
@@ -22,8 +23,15 @@ func main() {
 
 	authCli := coze.NewTokenAuth(token)
 
+	customClient := &http.Client{
+		Timeout: time.Minute * 20,
+	}
+
 	// Init the Coze client through the access_token.
-	cozeCli := coze.NewCozeAPI(authCli, coze.WithBaseURL(os.Getenv("COZE_API_BASE")))
+	cozeCli := coze.NewCozeAPI(authCli,
+		coze.WithBaseURL(os.Getenv("COZE_API_BASE")),
+		coze.WithHttpClient(customClient),
+	)
 
 	//
 	// Step one, create chats

--- a/examples/chats/submit_tool_output/main.go
+++ b/examples/chats/submit_tool_output/main.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/coze-dev/coze-go"
 )
@@ -19,8 +21,15 @@ func main() {
 
 	authCli := coze.NewTokenAuth(token)
 
+	customClient := &http.Client{
+		Timeout: time.Minute * 20,
+	}
+
 	// Init the Coze client through the access_token.
-	cozeCli := coze.NewCozeAPI(authCli, coze.WithBaseURL(os.Getenv("COZE_API_BASE")))
+	cozeCli := coze.NewCozeAPI(authCli,
+		coze.WithBaseURL(os.Getenv("COZE_API_BASE")),
+		coze.WithHttpClient(customClient),
+	)
 
 	ctx := context.Background()
 

--- a/examples/workflows/chat/stream/main.go
+++ b/examples/workflows/chat/stream/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"time"
 
@@ -29,8 +30,15 @@ func main() {
 	botID := os.Getenv("COZE_BOT_ID")
 	authCli := coze.NewTokenAuth(token)
 
+	customClient := &http.Client{
+		Timeout: time.Minute * 20,
+	}
+
 	// Init the Coze client through the access_token.
-	cozeCli := coze.NewCozeAPI(authCli, coze.WithBaseURL(os.Getenv("COZE_API_BASE")))
+	cozeCli := coze.NewCozeAPI(authCli,
+		coze.WithBaseURL(os.Getenv("COZE_API_BASE")),
+		coze.WithHttpClient(customClient),
+	)
 
 	//
 	// Step one, create chats


### PR DESCRIPTION
我为以下4个流式传输样例添加了20分钟的HTTP客户端超时配置：
examples/workflows/chat/stream/main.go
examples/chats/stream/main.go
examples/chats/chat_with_image/main.go
examples/chats/submit_tool_output/main.go

我在试运行chat流式响应的代码的时候遇到了HTTP客户端超时的小错误
这些流式响应的例子原本只有默认5秒的http客户端超时时间，大部分情况下会超时