### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: [ '1.18', '1.19', '1.20', '1.21', '1.22' , '1.23' , '1.24']
@@ -69,6 +71,8 @@ jobs:
     name: "Test success"
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [ test ]
     steps:
       - name: "Success"
@@ -82,6 +86,8 @@ jobs:
 
   draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     needs: test_success
     if: github.ref == 'refs/heads/main'
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/coze-dev/coze-go/security/code-scanning/3](https://github.com/coze-dev/coze-go/security/code-scanning/3)

To address the problem, add a `permissions` key to the workflow YAML file. This can be placed at the root for all jobs, or set per-job with the minimal privileges each requires. Since the “test” and “test_success” jobs likely only require read access (`contents: read`), but the “draft” job, which runs `release-drafter`, typically needs to write releases (via `contents: write`), it's safest and most precise to set `permissions:` on each job accordingly. Place:

- `permissions: contents: read` for the `test` and `test_success` jobs.
- `permissions: contents: write` for the `draft` job.

Add each `permissions:` block immediately under the job's top-level keys (after `runs-on` if possible) in `.github/workflows/ci.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened CI pipeline permissions to follow least-privilege principles, reducing default token scopes and limiting write access to necessary tasks only.
* **Chores**
  * Updated automation settings for continuous integration jobs without altering build/test steps or application behavior.

No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->