### PR TITLE
feat: Update audio_speech.go add emotion and emotion_scale

### DIFF
--- a/audio_speech.go
+++ b/audio_speech.go
@@ -26,6 +26,8 @@ type CreateAudioSpeechReq struct {
 	Speed          *float32     `json:"speed"`
 	SampleRate     *int         `json:"sample_rate"`
 	LoudnessRate   *int         `json:"loudness_rate"`
+	Emotion        *string      `json:"emotion"`
+	EmotionScale   *float32     `json:"emotion_scale"`
 }
 
 // CreateAudioSpeechResp represents the response for creating speech


### PR DESCRIPTION
add emotion and emotion_scale parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added optional “emotion” and “emotion_scale” parameters to audio speech synthesis requests, allowing finer control over vocal expressiveness.
  - These parameters are fully optional; existing integrations continue to work unchanged.
  - When provided, “emotion” selects the desired emotional tone, and “emotion_scale” adjusts its intensity for more nuanced output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->