### PR TITLE
fix: Fix fileKey assignment logic in file upload utility

### DIFF
--- a/request.go
+++ b/request.go
@@ -290,11 +290,12 @@ func (r *rawHttpRequest) parseRawRequestReqBody(body interface{}, isFile bool) e
 					fieldVV = fieldVV.Elem()
 				}
 				j = strings.TrimSuffix(j, ",omitempty")
-				fileKey = j
 				if r, ok := fieldVV.Interface().(FileTypes); ok {
+					fileKey = j
 					reader = r
 					fileName = r.Name()
 				} else if r, ok := fieldVV.Interface().(io.Reader); ok {
+					fileKey = j
 					reader = r
 				} else if j == "filename" {
 					fileName = reflectToString(fieldVV)
@@ -321,6 +322,9 @@ func (r *rawHttpRequest) parseRawRequestReqBody(body interface{}, isFile bool) e
 	}
 
 	if isFile {
+		if fileKey == "" {
+			fileKey = "file"
+		}
 		contentType, bod, err := newFileUploadRequest(fileData, fileKey, fileName, reader)
 		if err != nil {
 			return err


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of multipart file uploads: the form field key is now chosen based on the detected file type or the “filename” key, with a safe default to “file” when unspecified. This prevents upload failures due to missing or mismatched keys and improves compatibility with third-party clients.
  * Ensures more consistent and predictable behavior for file uploads across endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->