### PR TITLE
feat: add workflow version

### DIFF
--- a/workflows_runs.go
+++ b/workflows_runs.go
@@ -185,6 +185,10 @@ type RunWorkflowsReq struct {
 	IsAsync bool `json:"is_async,omitempty"`
 
 	AppID string `json:"app_id,omitempty"`
+
+	// The workflow version is valid only when the workflow is from the repository.
+	// If no version is specified, the latest version is executed by default.
+	WorkflowVersion string `json:"workflow_version,omitempty"`
 }
 
 // ResumeRunWorkflowsReq represents request for resuming workflow runs


### PR DESCRIPTION
Added the WorkflowVersion parameter to the RunWorkflowsReq request model.
This parameter allows users to specify the target workflow version when initiating a request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now specify a workflow version when executing workflows from a repository. This is optional, allowing workflows to run without specifying a version for backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->